### PR TITLE
Fix safari login issue

### DIFF
--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -36,7 +36,7 @@ let { getSession, commitSession, destroySession } = createCookieSessionStorage({
     sameSite: "lax",
     path: "/",
     maxAge: 60 * 60 * 24 * 30,
-    httpOnly: true,
+    httpOnly: process.env.NODE_ENV === "production",
   },
 });
 


### PR DESCRIPTION
In Safari login does not work for me locally (without any extensions) if secure is set to true. This change will only set it to true only if the node environment is production.