### PR TITLE
fix: protocol check for https upgrade

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,7 @@ export let loader: LoaderFunction = ({ request }) => {
 
   let url = new URL(request.url);
   let hostname = url.hostname;
-  let proto = request.headers.get("X-Forwarded-Proto") ?? url.protocol;
+  let proto = request.headers.get("X-Forwarded-Proto") ?? url.protocol.slice(0, -1);
 
   url.host =
     request.headers.get("X-Forwarded-Host") ??


### PR DESCRIPTION
Looks like the `proto === "http"` wouldn't work properly for http requests that don't have an `X-Forwarded-Proto` header because `URL.proto` returns a string with a colon at the end (e.g. `http:`, `https:`, etc.).

I wasn't able to actually find an issue visiting the site in my browser, but maybe there's something else at play (e.g. I noticed `Upgrade-Insecure-Requests: 1` attached to my requests). Seems like a good idea to fix anyway.